### PR TITLE
Feat/refactor/channel create modal (#15)

### DIFF
--- a/backend/controller/channel/channel.js
+++ b/backend/controller/channel/channel.js
@@ -259,7 +259,6 @@ const updateChannelSection = async (req, res, next) => {
 const createChannel = asyncWrapper(async (req, res) => {
   const { code, success, data } = await service.createChannel({
     ...req.body,
-    creator: req.user,
   })
   return res.status(code).json({ success, data })
 })

--- a/backend/controller/channel/index.js
+++ b/backend/controller/channel/index.js
@@ -1,13 +1,14 @@
 const express = require('express')
 const router = express.Router()
 const controller = require('./channel')
+const { Auth } = require('../../middleware/auth')
 
 /* GET /api/channle  get channel list  */
 router.get('/', controller.getChannelList)
 
 router.get('/check-duplicate-name', controller.checkDuplicate)
 
-router.post('/', controller.createChannel)
+router.post('/', Auth, controller.createChannel)
 
 /* GET /api/channle/{channelId}/info  get channel header info  */
 router.get('/:channelId/info', controller.getChannelHeaderInfo)

--- a/backend/util/index.js
+++ b/backend/util/index.js
@@ -9,7 +9,7 @@ const asyncWrapper = callback => {
 
 const verifyRequiredParams = (...params) => {
   for (const param of params)
-    if (!param)
+    if (isEmpty(param))
       throw { status: statusCode.BAD_REQUEST, message: resMessage.OUT_OF_VALUE }
 }
 
@@ -25,4 +25,11 @@ const dbErrorHandler = callback => {
   }
 }
 
-module.exports = { asyncWrapper, verifyRequiredParams, dbErrorHandler }
+const isEmpty = value => {
+  if (value === null) return true
+  if (typeof value === 'undefined') return true
+  if (typeof value === 'string' && value === '') return true
+  if (typeof value === 'object' && !Object.keys(value).length) return true
+  return false
+}
+module.exports = { asyncWrapper, verifyRequiredParams, dbErrorHandler, isEmpty }

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -1,6 +1,7 @@
 import { addDecorator } from '@storybook/react'
 import GlobalStyle from '../src/atom/GlobalStyle/GlobalStyle'
 import { RecoilRoot } from 'recoil'
+import { MemoryRouter } from 'react-router-dom'
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
 }
@@ -8,6 +9,8 @@ export const parameters = {
 addDecorator(story => (
   <>
     <GlobalStyle />
-    <RecoilRoot>{story()}</RecoilRoot>
+    <RecoilRoot>
+      <MemoryRouter initialEntries={['/']}>{story()}</MemoryRouter>
+    </RecoilRoot>
   </>
 ))

--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -1,6 +1,6 @@
 import { addDecorator } from '@storybook/react'
 import GlobalStyle from '../src/atom/GlobalStyle/GlobalStyle'
-
+import { RecoilRoot } from 'recoil'
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
 }
@@ -8,6 +8,6 @@ export const parameters = {
 addDecorator(story => (
   <>
     <GlobalStyle />
-    {story()}
+    <RecoilRoot>{story()}</RecoilRoot>
   </>
 ))

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17160,6 +17160,11 @@
         "resolve": "^1.1.6"
       }
     },
+    "recoil": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.1.2.tgz",
+      "integrity": "sha512-hIRrHlkmW4yITlBFprVYjVPhzPKYrJKoaDrrJtAtbkMeXfXaa/XE5OlyR10n+rNfnKWNToCKb3Z4fo86IGjkzg=="
+    },
     "recursive-readdir": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
     "react-toastify": "^6.1.0",
+    "recoil": "^0.1.2",
     "socket.io-client": "^3.0.3",
     "styled-components": "^5.2.1",
     "web-vitals": "^0.2.4"

--- a/frontend/src/api/channel.js
+++ b/frontend/src/api/channel.js
@@ -1,0 +1,15 @@
+import Request from '../util/request'
+export const checkDuplicateChannelName = async ({ title, workspaceId }) => {
+  const { data } = await Request.GET('/api/channel/check-duplicate-name', {
+    title,
+    workspaceId,
+  })
+  return data.data
+}
+
+export const createChannel = async params => {
+  const { data } = await Request.POST('/api/channel', {
+    ...params,
+  })
+  return data?.data?._id
+}

--- a/frontend/src/atom/Button/Button.js
+++ b/frontend/src/atom/Button/Button.js
@@ -22,14 +22,13 @@ const StyledButton = styled.button`
   border-radius: 4px;
   outline: none;
   color: ${({ type, disabled }) => {
-    if (disabled) return COLOR.LIGHT_GRAY
-    if (type === 'transparent') return COLOR.LIGHT_GRAY
-    if (type === 'icon') return COLOR.TRANSPARENT_GRAY
+    if (disabled) return COLOR.GRAY
+    if (type === 'transparent') return COLOR.GRAY
     return COLOR.WHITE
   }};
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
   background-color: ${({ type, disabled }) => {
-    if (disabled) return COLOR.GRAY
+    if (disabled) return COLOR.LIGHT_GRAY
     if (type === 'transparent') return 'transparent'
     if (type === 'icon') return 'transparent'
     return COLOR.GREEN
@@ -48,8 +47,17 @@ const StyledButton = styled.button`
       if (type === 'default')
         return `background: ${COLOR.HOVER_GREEN}; box-shadow: 0 1px 4px rgba(0,0,0,0.3);`
       if (type === 'icon')
-        return `background: ${COLOR.HOVER_GRAY}; box-shadow:0 1px 3px 0 rgba(0,0,0, 0.08); color: ${COLOR.DARK_GRAY}`
+        return `background: ${COLOR.HOVER_GRAY}; 
+                box-shadow:0 1px 3px 0 rgba(0,0,0, 0.08);`
     }}
   }
+  ${({ type }) => {
+    if (type === 'icon')
+      return `
+        &:hover i svg {
+          color: ${COLOR.ICON_HOVER};
+        }
+      `
+  }}
 `
 export default Button

--- a/frontend/src/atom/Button/ToggleButton/ToggleButton.js
+++ b/frontend/src/atom/Button/ToggleButton/ToggleButton.js
@@ -1,0 +1,87 @@
+import React from 'react'
+import styled from 'styled-components'
+import { COLOR } from '../../../constant/style'
+const ToggleButton = ({ value, handleChange }) => {
+  return (
+    <StyledToggleWrapper>
+      <StyledToggleInput
+        type="checkbox"
+        checked={value}
+        onChange={handleChange}
+      />
+      <StyledSwitchVisual tabIndex="-1" />
+    </StyledToggleWrapper>
+  )
+}
+const StyledToggleWrapper = styled.div`
+  position: relative;
+  display: inline-block;
+  line-height: 0;
+`
+const StyledSwitchVisual = styled.div`
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  input:checked + &:before {
+    opacity: 1;
+    position: absolute;
+    color: ${COLOR.WHITE};
+  }
+  ::before {
+    content: '✔';
+    top: 5px;
+    left: 8px;
+    display: inline-block;
+    font-size: 17px;
+    font-style: normal;
+    font-weight: 900;
+    line-height: 1;
+    opacity: 0;
+    position: absolute;
+    transition: opacity 0.1s ease-in;
+  }
+  input:checked + &:after {
+    background-color: ${COLOR.WHITE};
+    transform: translate3d(22px, 0, 0);
+  }
+  ::after {
+    content: '';
+    position: absolute;
+    top: 5px;
+    left: 6px;
+    width: 20px;
+    height: 20px;
+    border-radius: 100%;
+    background-color: ${COLOR.GRAY};
+    transform-origin: center;
+    transform: translateZ(0);
+    transition: transform 0.1s ease-in, background-color 0.1s ease-in;
+  }
+`
+const StyledToggleInput = styled.input`
+  &:focus-within {
+    outline: none;
+    box-shadow: 0 0 0 1px rgba(18, 100, 163, 1),
+      0 0 0 5px rgba(29, 155, 209, 0.3);
+    border-radius: 18px;
+    border-color: transparent;
+  }
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  outline: none;
+  margin: 0;
+  width: 54px;
+  height: 30px;
+  border: 1px solid ${COLOR.GRAY};
+  border-radius: 18px;
+  background-color: ${COLOR.WHITE};
+  cursor: pointer;
+  transition: background-color 0.1s ease-in;
+  :checked {
+    background-color: ${COLOR.GREEN};
+    border: none;
+  }
+`
+export default ToggleButton

--- a/frontend/src/atom/Button/ToggleButton/ToggleButton.stories.js
+++ b/frontend/src/atom/Button/ToggleButton/ToggleButton.stories.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import Toggle from './ToggleButton'
+import { storiesOf } from '@storybook/react'
+const stories = storiesOf('Atom/Button', module)
+const TestComponent = () => {
+  const [value, setValue] = React.useState(false)
+  const handleChange = () => {
+    console.log(value)
+    setValue(!value)
+  }
+  return <Toggle handleChange={handleChange} value={value} />
+}
+stories.add('ToggleButton', () => <TestComponent />)

--- a/frontend/src/atom/Button/ToggleButton/index.js
+++ b/frontend/src/atom/Button/ToggleButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './ToggleButton'

--- a/frontend/src/atom/Icon/Icon.js
+++ b/frontend/src/atom/Icon/Icon.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-const Icon = ({ icon, size, color }) => {
+const Icon = ({ icon, size, color, padding }) => {
   return (
-    <StyledIcon size={size}>
+    <StyledIcon size={size} padding={padding}>
       <FontAwesomeIcon icon={icon} color={color || 'black'} />
     </StyledIcon>
   )
 }
 const StyledIcon = styled.i`
   font-size: ${({ size }) => (size ? size : '1rem')};
+  padding: ${({ padding }) => padding};
 `
 export default Icon

--- a/frontend/src/atom/Input/Input.js
+++ b/frontend/src/atom/Input/Input.js
@@ -1,14 +1,58 @@
 import React from 'react'
-
-function Input({ placeholder, handleChange, handleKey, value }) {
+import styled from 'styled-components'
+import { COLOR } from '../../constant/style'
+function Input({
+  children,
+  placeholder,
+  handleChange,
+  handleKey,
+  value,
+  maxLength,
+}) {
   return (
-    <input
-      placeholder={placeholder}
-      onChange={handleChange}
-      onKeyDown={handleKey}
-      value={value}
-    />
+    <StyledInputWrapper tabIndex="0">
+      {children}
+      <StyledInput
+        placeholder={placeholder}
+        onChange={handleChange}
+        onKeyDown={handleKey}
+        value={value}
+      />
+      {maxLength && (
+        <StyledMaxLength>{maxLength - value.length}</StyledMaxLength>
+      )}
+    </StyledInputWrapper>
   )
 }
+const StyledInputWrapper = styled.div`
+  &:focus-within {
+    outline: none;
+    box-shadow: 0 0 0 1px rgba(18, 100, 163, 1),
+      0 0 0 5px rgba(29, 155, 209, 0.3);
+    border-radius: 4px;
+    border-color: transparent;
+  }
+  &:focus-within > div {
+    display: block;
+  }
+  border: 1px solid ${COLOR.TRANSPARENT_GRAY};
+  border-radius: 4px;
+  justify-content: space-between;
+  display: flex;
+  padding: 5px;
+`
+const StyledMaxLength = styled.div`
+  display: none;
+  margin-left: 10px;
+  color: ${COLOR.DARK_GRAY};
+`
+const StyledInput = styled.input`
+  font-size: 18px;
+  line-height: 1.33334;
+  font-weight: 400;
+  width: 100%;
+  border: none;
+  outline: none;
+`
 
 export default Input

--- a/frontend/src/atom/Input/Input.js
+++ b/frontend/src/atom/Input/Input.js
@@ -42,6 +42,9 @@ const StyledInputWrapper = styled.div`
   padding: 5px;
 `
 const StyledMaxLength = styled.div`
+  font-size: 18px;
+  line-height: 1.33334;
+  font-weight: 400;
   display: none;
   margin-left: 10px;
   color: ${COLOR.DARK_GRAY};

--- a/frontend/src/atom/Input/Input.js
+++ b/frontend/src/atom/Input/Input.js
@@ -10,16 +10,17 @@ function Input({
   maxLength,
 }) {
   return (
-    <StyledInputWrapper tabIndex="0">
+    <StyledInputWrapper tabIndex="-1">
       {children}
       <StyledInput
         placeholder={placeholder}
         onChange={handleChange}
         onKeyDown={handleKey}
         value={value}
+        tabIndex="0"
       />
       {maxLength && (
-        <StyledMaxLength>{maxLength - value.length}</StyledMaxLength>
+        <StyledMaxLength>{maxLength - value?.length}</StyledMaxLength>
       )}
     </StyledInputWrapper>
   )

--- a/frontend/src/atom/Input/Input.stories.js
+++ b/frontend/src/atom/Input/Input.stories.js
@@ -1,18 +1,25 @@
 import React from 'react'
 import Input from './Input'
 import { action } from '@storybook/addon-actions'
-
+import Icon from '../Icon'
+import { HASHTAG } from '../../constant/icon'
 export default {
-  title: 'Example/Input',
+  title: 'Atom/Input',
   component: Input,
 }
 
 const Template = args => <Input {...args} />
 
-export const MessageInput = Template.bind({})
-MessageInput.args = {
+export const Default = Template.bind({})
+Default.args = {
   placeholder: 'Send a message to #example',
-  handleChange: action(e => {
-    console.log(e.target.value)
-  }),
+  value: 'text',
+}
+
+export const WithIcon = Template.bind({})
+WithIcon.args = {
+  placeholder: 'Send a message to #example',
+  value: 'text',
+  children: <Icon icon={HASHTAG} />,
+  maxLength: 80,
 }

--- a/frontend/src/constant/style.js
+++ b/frontend/src/constant/style.js
@@ -1,10 +1,10 @@
 const COLOR = {
   DARK_GRAY: '#4d4c4d',
-  LIGHT_GRAY: '#616061',
+  LIGHT_GRAY: '#ddd',
   HOVER_GRAY: '#f6f6f6',
-  GRAY: '#ddd',
+  GRAY: '#616061',
   TRANSPARENT_GRAY: 'rgba(29, 28, 29, 0.3)',
-  HOVER_TEXT_GRAY: 'rgba(29, 28, 29, 0.3)',
+  ICON_HOVER: '#1d1c1d',
   GREEN: '#007a5a',
   HOVER_GREEN: '#148567',
   WHITE: '#fff',

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -10,29 +10,35 @@ import LoginPage from './page/login/Login'
 import WorkspaceSelectPage from './page/WorkspaceSelectPage'
 import Auth from './hooks/Auth'
 import GithubOAuth from './hooks/GithubOAuth'
+import { RecoilRoot } from 'recoil'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 
 const App = () => {
   return (
-    <React.StrictMode>
-      <ToastContainer />
-      <GlobalStyle />
-      <BrowserRouter>
-        <Route exact path="/" component={Channel} />
-        <Route exact path="/login" component={Auth(LoginPage, false)} />
-        <Route path="/github-oauth" component={GithubOAuth(LoginPage, false)} />
-        <Route
-          exact
-          path="/workspace-select"
-          component={Auth(WorkspaceSelectPage, true)}
-        />
-        <Route
-          path="/workspace/:channelId"
-          component={Auth(WorkspacePage, false)}
-        />
-      </BrowserRouter>
-    </React.StrictMode>
+    <RecoilRoot>
+      <React.StrictMode>
+        <ToastContainer />
+        <GlobalStyle />
+        <BrowserRouter>
+          <Route exact path="/" component={Channel} />
+          <Route exact path="/login" component={Auth(LoginPage, false)} />
+          <Route
+            path="/github-oauth"
+            component={GithubOAuth(LoginPage, false)}
+          />
+          <Route
+            exact
+            path="/workspace-select"
+            component={Auth(WorkspaceSelectPage, true)}
+          />
+          <Route
+            path="/workspace/:channelId"
+            component={Auth(WorkspacePage, false)}
+          />
+        </BrowserRouter>
+      </React.StrictMode>
+    </RecoilRoot>
   )
 }
 

--- a/frontend/src/organism/CreateChannelModal/CreateChannelModal.js
+++ b/frontend/src/organism/CreateChannelModal/CreateChannelModal.js
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react'
 import styled from 'styled-components'
 import { useRecoilValue } from 'recoil'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useParams } from 'react-router-dom'
 
 import { workspace } from '../../store'
 import Modal from '../../atom/Modal'
@@ -29,13 +29,13 @@ const DUPLICATED_NAME_ERROR =
 
 const CreateChannelModal = ({ handleClose }) => {
   const history = useHistory()
-  const { workspaceId, workspaceUseInfoId } = useRecoilValue(workspace)
+  const { workspaceId } = useParams()
+  const { workspaceUseInfoId } = useRecoilValue(workspace)
   const [isPrivate, setPrivateOption] = useState(false)
   const [channelName, setChannelName] = useState('')
   const [channelDescription, setChannelDescription] = useState('')
   const [nameError, setNameError] = useState('')
   const [descriptionError, setDescriptionError] = useState('')
-
   const checkDuplicateName = async title => {
     if (
       title &&

--- a/frontend/src/organism/CreateChannelModal/CreateChannelModal.js
+++ b/frontend/src/organism/CreateChannelModal/CreateChannelModal.js
@@ -9,6 +9,8 @@ import { CLOSE, HASHTAG, LOCK } from '../../constant/icon'
 import { debounce } from '../../util'
 import Request from '../../util/request'
 import { COLOR } from '../../constant/style'
+
+const maxChannelName = 80
 const CreateChannelModal = ({ handleClose }) => {
   const [isPrivate, setPrivateOption] = useState(false)
   const [channelName, setChannelName] = useState('')
@@ -46,12 +48,14 @@ const CreateChannelModal = ({ handleClose }) => {
         <strong>Name</strong>
         {errorMessage}
         <div>
-          <Icon icon={isPrivate ? LOCK : HASHTAG} />
           <Input
             placeholder="e.g. plan-budget"
             handleChange={handleChange(setChannelName, handleDebounce)}
             value={channelName}
-          />
+            maxLength={maxChannelName}
+          >
+            <Icon icon={isPrivate ? LOCK : HASHTAG} padding="5px" />
+          </Input>
         </div>
         <Button
           handleClick={submitChannelInfo}

--- a/frontend/src/organism/CreateChannelModal/CreateChannelModal.stories.js
+++ b/frontend/src/organism/CreateChannelModal/CreateChannelModal.stories.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { RecoilRoot } from 'recoil'
 import CreateChannelModal from './CreateChannelModal'
 import { storiesOf } from '@storybook/react'
 const portal = document.createElement('div')
@@ -11,10 +12,10 @@ const TestComponent = () => {
     setVisible(!visible)
   }
   return (
-    <div>
+    <RecoilRoot>
       <button onClick={handleClose}>Open Modal</button>
       {visible ? <CreateChannelModal handleClose={handleClose} /> : ''}
-    </div>
+    </RecoilRoot>
   )
 }
 stories.add('CreateChannelModal', () => <TestComponent />)

--- a/frontend/src/organism/CreateChannelModal/CreateChannelModal.stories.js
+++ b/frontend/src/organism/CreateChannelModal/CreateChannelModal.stories.js
@@ -1,7 +1,7 @@
 import React from 'react'
-import { RecoilRoot } from 'recoil'
 import CreateChannelModal from './CreateChannelModal'
 import { storiesOf } from '@storybook/react'
+
 const portal = document.createElement('div')
 portal.setAttribute('id', 'portal')
 document.querySelector('body').appendChild(portal)
@@ -12,10 +12,10 @@ const TestComponent = () => {
     setVisible(!visible)
   }
   return (
-    <RecoilRoot>
+    <>
       <button onClick={handleClose}>Open Modal</button>
       {visible ? <CreateChannelModal handleClose={handleClose} /> : ''}
-    </RecoilRoot>
+    </>
   )
 }
 stories.add('CreateChannelModal', () => <TestComponent />)

--- a/frontend/src/organism/ModalInputSection/ModalInputSection.js
+++ b/frontend/src/organism/ModalInputSection/ModalInputSection.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import styled from 'styled-components'
+import { COLOR } from '../../constant/style'
+const ModalInputSection = ({
+  name,
+  optionalText,
+  errorMessage,
+  children,
+  description,
+}) => {
+  return (
+    <StyledWrapper>
+      <StyledInputName>
+        <StyledStrong>{name}</StyledStrong>
+        <StyledOptionalText>{optionalText}</StyledOptionalText>
+        <StyledErrorMessage>{errorMessage}</StyledErrorMessage>
+      </StyledInputName>
+      {children}
+      <StyledDescription>{description}</StyledDescription>
+    </StyledWrapper>
+  )
+}
+const StyledErrorMessage = styled.span`
+  display: inline-block;
+  font-weight: 700;
+  color: #e8912d;
+  word-break: break-all;
+`
+const StyledOptionalText = styled.span`
+  font-size: 15px;
+`
+const StyledDescription = styled.div`
+  margin: 5px 0;
+  font-size: 13px;
+  font-weight: 400;
+  color: ${COLOR.GRAY};
+`
+const StyledStrong = styled.strong`
+  margin-right: 10px;
+`
+const StyledWrapper = styled.div`
+  margin: 20px 0;
+`
+const StyledInputName = styled.div`
+  margin: 10px 0;
+`
+
+export default ModalInputSection

--- a/frontend/src/organism/ModalInputSection/ModalInputSection.js
+++ b/frontend/src/organism/ModalInputSection/ModalInputSection.js
@@ -27,7 +27,9 @@ const StyledErrorMessage = styled.span`
   word-break: break-all;
 `
 const StyledOptionalText = styled.span`
+  display: inline-block;
   font-size: 15px;
+  color: ${COLOR.GRAY};
 `
 const StyledDescription = styled.div`
   margin: 5px 0;

--- a/frontend/src/organism/ModalInputSection/ModalInputSection.stories.js
+++ b/frontend/src/organism/ModalInputSection/ModalInputSection.stories.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import ModalInputSection from './ModalInputSection'
+import Input from '../../atom/Input'
+import { action } from '@storybook/addon-actions'
+import Icon from '../../atom/Icon'
+import { HASHTAG } from '../../constant/icon'
+export default {
+  title: 'Organism/Modal/ModalInputSection',
+  component: ModalInputSection,
+}
+
+const Template = args => <ModalInputSection {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  name: 'Name',
+  description: 'text',
+  errorMessage: 'hello error message',
+  children: (
+    <Input>
+      <Icon icon={HASHTAG} />
+    </Input>
+  ),
+}

--- a/frontend/src/organism/ModalInputSection/index.js
+++ b/frontend/src/organism/ModalInputSection/index.js
@@ -1,0 +1,1 @@
+export { default } from './ModalInputSection'

--- a/frontend/src/page/channel/Channel.js
+++ b/frontend/src/page/channel/Channel.js
@@ -2,7 +2,7 @@ import React from 'react'
 import MessageEditor from '../../organism/messageEditor/MessageEditor'
 import io from 'socket.io-client'
 import { useState, useEffect } from 'react'
-
+import CreateChannelModal from '../../organism/CreateChannelModal'
 const baseURL =
   process.env.NODE_ENV === 'development'
     ? process.env.REACT_APP_DEV_CHAT_HOST
@@ -41,6 +41,7 @@ function Channel() {
     <div>
       {/* TODO messgae component channel header component 추가 필요 */}
       <MessageEditor channelTitle={'hello world'} sendMessage={sendMessage} />
+      <CreateChannelModal />
     </div>
   )
 }

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,0 +1,6 @@
+import { atom } from 'recoil'
+
+export const workspace = atom({
+  key: 'workspaceId',
+  default: '',
+})

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -3,7 +3,6 @@ import { atom } from 'recoil'
 export const workspace = atom({
   key: 'workspace',
   default: {
-    workspaceId: '5fc4fe2faa1ecd6a71dde1a8',
     workspaceUseInfoId: '5fc4fe427b2d5f6ae44dc15d',
   },
 })

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,6 +1,9 @@
 import { atom } from 'recoil'
 
 export const workspace = atom({
-  key: 'workspaceId',
-  default: '',
+  key: 'workspace',
+  default: {
+    workspaceId: '5fc4fe2faa1ecd6a71dde1a8',
+    workspaceUseInfoId: '5fc4fe427b2d5f6ae44dc15d',
+  },
 })


### PR DESCRIPTION
## Linked Issue
close #15 

## 공유할 사항
- recoil을 적용해보았습니다. workspaceId, workspaceUserInfoId를 frontend 에서 유지한다면 global store에 저장하면 될 것 같습니다.
- channel create modal 관련 로직을 전반적으로 수정하다보니까 pr이 또 커진 것 같네요 ㅠ

## 논의할 사항
- request.js에서 return 값을 data로 변경하면 어떨까요? 현재는 response를 그대로 반환하는데 관심사는 data이기 때문에 data를 반환하면 반복되는 코드가 더 줄어들 것 같습니다.
- api 경로를 작성해야하는 것이 마음에 들지 않아서 api.js를 만들어보았습니다. 괜찮은지 봐주세용
- frontend routing 경로? 를 정해야 할 것 같습니다. 예를 들면 https://slack.com/workspaceid/channelId 어떤 경로에서 어떤 화면을 보여주고 컴폰넌트를 어떻게 렌더링할 지를 정해봅시다!
- db default 값을 설정한 부분이 없더라구여 isDelete인 경우는 생성될 때 false로 기본 값을 설정해주면 좋을 것 같습니다. 
> 적용해서 테스트 해봤는데 https://cloud.mongodb.com 사이트에서는 default 값을 설정해도 적용이 안 되는 것 같습니다.. 왜 그럴까요?
