### PR TITLE
slack icon to slack img

### DIFF
--- a/frontend/src/atom/SlackIcon/index.js
+++ b/frontend/src/atom/SlackIcon/index.js
@@ -1,1 +1,0 @@
-export { default } from './SlackIcon'

--- a/frontend/src/atom/SlackImage/SlackImage.js
+++ b/frontend/src/atom/SlackImage/SlackImage.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-function SlackIcon({ onClick }) {
+function SlackImage({ onClick }) {
   return (
     <>
       <ImgDiv>
@@ -21,4 +21,4 @@ const ImgDiv = styled.div`
   cursor: pointer;
 `
 
-export default SlackIcon
+export default SlackImage

--- a/frontend/src/atom/SlackImage/SlackImage.js
+++ b/frontend/src/atom/SlackImage/SlackImage.js
@@ -3,21 +3,17 @@ import styled from 'styled-components'
 
 function SlackImage({ onClick }) {
   return (
-    <>
-      <ImgDiv>
-        <img
-          alt="Slack"
-          src="https://a.slack-edge.com/bv1-8/slack_logo-ebd02d1.svg"
-          height="34"
-          title="Slack"
-          onClick={onClick}
-        ></img>
-      </ImgDiv>
-    </>
+    <StyledImg
+      alt="Slack"
+      src="https://a.slack-edge.com/bv1-8/slack_logo-ebd02d1.svg"
+      height="34"
+      title="Slack"
+      onClick={onClick}
+    />
   )
 }
 
-const ImgDiv = styled.div`
+const StyledImg = styled.img`
   cursor: pointer;
 `
 

--- a/frontend/src/atom/SlackImage/SlackImage.stories.js
+++ b/frontend/src/atom/SlackImage/SlackImage.stories.js
@@ -1,14 +1,14 @@
 import React from 'react'
-import SlackIcon from './SlackIcon'
+import SlackImage from './SlackImage'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 export default {
   title: 'Example/SlackIcon',
-  component: SlackIcon,
+  component: SlackImage,
 }
 
-const Template = args => <SlackIcon {...args} />
+const Template = args => <SlackImage {...args} />
 
 export const Default = Template.bind({})
 Default.args = {}

--- a/frontend/src/atom/SlackImage/index.js
+++ b/frontend/src/atom/SlackImage/index.js
@@ -1,0 +1,1 @@
+export { default } from './SlackImage'

--- a/frontend/src/page/login/Login.js
+++ b/frontend/src/page/login/Login.js
@@ -4,7 +4,7 @@ import LoginButton from '../../atom/LoginButton/LoginButton'
 import { GITHUB } from '../../constant/icon'
 import Icon from '../../atom/Icon'
 import styled from 'styled-components'
-import SlackIcon from '../../atom/SlackIcon'
+import SlackIcon from '../../atom/SlackImage'
 
 const baseURL =
   process.env.NODE_ENV === 'development'


### PR DESCRIPTION


## Linked Issue
close #

## 공유할 사항
- slack icon 파일 이름을 slack img로 변경

## 논의할 사항
- 본래 계획은 slakc img에 있는 img태그를 atom으로 만드는 것이었습니다.
- 그러나 img 태그를 공통으로 사용하는 UserProfileImg와 필요한 속성이 너무 달라 오히려 불필요한 분리가 될 것으로 보여 보류하였습니다.
