### PR TITLE
Refactor: github profile img 없을 경우 default image url 설정

### DIFF
--- a/backend/config/passport.js
+++ b/backend/config/passport.js
@@ -18,7 +18,9 @@ async function gitStrategyLogin(profiles) {
       const data = await User.create({
         OAuthId: profiles.id,
         fullName: profiles.username,
-        profileUrl: profiles.photos[0].value,
+        profileUrl:
+          profiles.photos[0].value ||
+          'https://user-images.githubusercontent.com/56837413/102013276-583f6000-3d92-11eb-8184-186bc09f2a98.jpg',
         isDeleted: false,
       })
       return {

--- a/backend/config/passport.js
+++ b/backend/config/passport.js
@@ -19,7 +19,7 @@ async function gitStrategyLogin(profiles) {
         OAuthId: profiles.id,
         fullName: profiles.username,
         profileUrl:
-          profiles.photos[0].value ||
+          profiles?.photos[0]?.value ||
           'https://user-images.githubusercontent.com/56837413/102013276-583f6000-3d92-11eb-8184-186bc09f2a98.jpg',
         isDeleted: false,
       })


### PR DESCRIPTION
## Linked Issue
close #

## 공유할 사항
- github login시 profileUrl이 없을 경우에 default image url을 가질 수 있도록  예외처리를 해 주었습니다.

## 논의할 사항
- 없습니다. ❌
